### PR TITLE
requirements: support embedded targets

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -80,7 +80,7 @@ Needs we have ourselves or features we have seen requested but can not link too.
 - Microphone as input node to the audio graph @dvdsk. 
 - Add an output to the OS, any audio send to it enters the audio graph. @dvdsk
 - Add an input to the OS, it gets audio from an output of the audio graph. @dvdsk
-- Support features on capable embedded hardware where possible. With capable hardware we mean the target:
+- Have (partial) functionality on `no_std` targets. Such as capable embedded hardware. The targets need to at least:
     - Can supports 32 bit floating points through [libm](https://crates.io/crates/libm).
     - Has 32 bit float atomics via [portable-atomics](https://crates.io/crates/portable-atomic).
   This would allow applications such as: 

--- a/requirements.md
+++ b/requirements.md
@@ -4,6 +4,7 @@ Becoming the standard audio stack for Rust requires us to support near all neede
 To that end we start with features supported by popular Rust audio engines like *Kira* & *Rodio*. Requests of those engines also point to needed use-cases. Finally we hope to learn from looking at large projects using audio like *Bevy* and *Fyrox*.
 
 ### Supported by Kira
+
 - Smoothly adjusting properties of sounds without pops (via [tween](https://docs.rs/kira/latest/kira/struct.Tween.html))
 - Change the settings of effects automatically [modulate](https://docs.rs/kira/latest/kira/modulator/index.html)
 - Apply audio effects: 
@@ -79,3 +80,10 @@ Needs we have ourselves or features we have seen requested but can not link too.
 - Microphone as input node to the audio graph @dvdsk. 
 - Add an output to the OS, any audio send to it enters the audio graph. @dvdsk
 - Add an input to the OS, it gets audio from an output of the audio graph. @dvdsk
+- Support features on capable embedded hardware where possible. With capable hardware we mean the target:
+    - Supports 32 bit floating points.
+    - Has 32 bit float atomics.
+  This would allow applications such as: 
+    - (battery operated) Alarm clocks
+    - Light portable audio players
+  We might make this a soft requirement, meaning we attempt to achieve this if it does not take too much extra effort.

--- a/requirements.md
+++ b/requirements.md
@@ -81,8 +81,8 @@ Needs we have ourselves or features we have seen requested but can not link too.
 - Add an output to the OS, any audio send to it enters the audio graph. @dvdsk
 - Add an input to the OS, it gets audio from an output of the audio graph. @dvdsk
 - Support features on capable embedded hardware where possible. With capable hardware we mean the target:
-    - Supports 32 bit floating points.
-    - Has 32 bit float atomics.
+    - Can supports 32 bit floating points through [libm](https://crates.io/crates/libm).
+    - Has 32 bit float atomics via [portable-atomics](https://crates.io/crates/portable-atomic).
   This would allow applications such as: 
     - (battery operated) Alarm clocks
     - Light portable audio players


### PR DESCRIPTION
See also the discussion here: https://github.com/RustAudio/audio-ecosystem/pull/9

Few notes from me:
- This need is currently fulfilled by https://github.com/10buttons/awedio
- It has never seriously been requested from Rodio (except maybe [this](https://github.com/RustAudio/rodio/issues/723)) 
- Once hardware get fast enough to support more complex audio operations it can generally run an OS & do audio.